### PR TITLE
Call viewPortUpdate only for changed entries, with correct ratio

### DIFF
--- a/app/assets/public/index.html
+++ b/app/assets/public/index.html
@@ -24,5 +24,7 @@
         window.scriptsAreExecutedInBody = true;
       })();
     </script>
+    <div class="observer-test-1">Test1</div>
+    <div class="observer-test-2">Test2</div>
   </body>
 </html>

--- a/lib/IntersectionObserver.js
+++ b/lib/IntersectionObserver.js
@@ -15,6 +15,7 @@ module.exports = function FakeIntersectionObserver(browser) {
     const toObserve = [];
     const rootMargin = getRootMargin(options);
     browser.window.addEventListener("scroll", onScroll);
+    let previousEntries = [];
 
     return {
       disconnect() {
@@ -23,7 +24,9 @@ module.exports = function FakeIntersectionObserver(browser) {
       observe(element) {
         toObserve.push(element);
         observed.push(element);
-        onScroll();
+        const newEntries = [element].map(toEntry);
+        viewPortUpdate(newEntries);
+        previousEntries = previousEntries.concat(newEntries);
       },
       unobserve(element) {
         const idx = toObserve.indexOf(element);
@@ -34,16 +37,27 @@ module.exports = function FakeIntersectionObserver(browser) {
     };
 
     function onScroll() {
-      viewPortUpdate(makeEntries(toObserve.slice()));
+      const entries = toObserve.map(toEntry);
+      const changedEntries = entries.filter(hasChanged);
+
+      if (changedEntries.length > 0) {
+        viewPortUpdate(changedEntries);
+      }
+
+      previousEntries = entries;
     }
 
-    function makeEntries(observedEntries) {
-      return observedEntries.map((target) => {
-        const boundingClientRect = target.getBoundingClientRect();
-        const intersectionRatio = getIntersectionRatio(boundingClientRect, browser.window.innerHeight, rootMargin);
+    function hasChanged(entry) {
+      const previous = previousEntries.find((x) => x.target === entry.target);
+      if (!previous) return true;
+      return entry.intersectionRatio !== previous.intersectionRatio;
+    }
 
-        return {target, boundingClientRect, intersectionRatio};
-      });
+    function toEntry(element) {
+      const boundingClientRect = element.getBoundingClientRect();
+      const intersectionRatio = getIntersectionRatio(boundingClientRect, browser.window.innerHeight, rootMargin);
+
+      return {target: element, boundingClientRect, intersectionRatio};
     }
   }
 };

--- a/lib/intersectionCalc.js
+++ b/lib/intersectionCalc.js
@@ -29,13 +29,19 @@ function firstOf(...args) {
 }
 
 function getIntersectionRatio(boundingClientRect, windowInnerHeight, rootMargin = {}) {
-  const {top, height} = boundingClientRect;
+  const {top, height, bottom = top + height} = boundingClientRect;
   const {top: marginTop, bottom: marginBottom} = rootMargin;
 
-  const isBelowTop = (top + height) > -(marginTop || 0);
-  const isAboveBottom = top < windowInnerHeight + (marginBottom || 0);
+  const topIntersection = -(marginTop || 0);
+  const bottomIntersection = windowInnerHeight + (marginBottom || 0);
 
-  const isInside = isBelowTop && isAboveBottom;
+  if (top < topIntersection) {
+    return Math.max((bottom - topIntersection) / height, 0);
+  }
 
-  return isInside ? 1 : 0;
+  if (bottom > bottomIntersection) {
+    return Math.max((bottomIntersection - top) / height, 0);
+  }
+
+  return 1;
 }

--- a/test/intersection-calc-test.js
+++ b/test/intersection-calc-test.js
@@ -61,14 +61,14 @@ describe("Intersection Calc", () => {
         expect(result).to.equal(1);
       });
 
-      it("returns 1 when partially inside window (above)", () => {
+      it("returns 0.5 when partially inside window (above)", () => {
         const result = getIntersectionRatio({top: -50, height: 100}, 400);
-        expect(result).to.equal(1);
+        expect(result).to.equal(0.5);
       });
 
-      it("returns 1 when partially inside window (below)", () => {
+      it("returns 0.5 when partially inside window (below)", () => {
         const result = getIntersectionRatio({top: 350, height: 100}, 400);
-        expect(result).to.equal(1);
+        expect(result).to.equal(0.5);
       });
 
       it("returns 0 when above window", () => {
@@ -94,14 +94,14 @@ describe("Intersection Calc", () => {
         expect(result).to.equal(1);
       });
 
-      it("returns 1 when partially inside window with margins (above)", () => {
+      it("returns 0.5 when partially inside window with margins (above)", () => {
         const result = getIntersectionRatio({top: -150, height: 100}, 400, rootMargin);
-        expect(result).to.equal(1);
+        expect(result).to.equal(0.5);
       });
 
-      it("returns 1 when partially inside window with margins (below)", () => {
+      it("returns 0.5 when partially inside window with margins (below)", () => {
         const result = getIntersectionRatio({top: 350, height: 100}, 400, rootMargin);
-        expect(result).to.equal(1);
+        expect(result).to.equal(0.5);
       });
 
       it("returns 0 when above window with margins", () => {
@@ -127,14 +127,14 @@ describe("Intersection Calc", () => {
         expect(result).to.equal(1);
       });
 
-      it("returns 1 when partially inside window (above)", () => {
+      it("returns 0.5 when partially inside window (above)", () => {
         const result = getIntersectionRatio({top: 50, height: 100}, 400, rootMargin);
-        expect(result).to.equal(1);
+        expect(result).to.equal(0.5);
       });
 
-      it("returns 1 when partially inside window (below)", () => {
+      it("returns 0.5 when partially inside window (below)", () => {
         const result = getIntersectionRatio({top: 350, height: 100}, 400, rootMargin);
-        expect(result).to.equal(1);
+        expect(result).to.equal(0.5);
       });
 
       it("returns 0 when above window", () => {
@@ -160,14 +160,14 @@ describe("Intersection Calc", () => {
         expect(result).to.equal(1);
       });
 
-      it("returns 1 when partially inside window with margins (above)", () => {
+      it("returns 0.5 when partially inside window with margins (above)", () => {
         const result = getIntersectionRatio({top: -50, height: 100}, 400, rootMargin);
-        expect(result).to.equal(1);
+        expect(result).to.equal(0.5);
       });
 
-      it("returns 1 when partially inside window with margins (below)", () => {
+      it("returns 0.5 when partially inside window with margins (below)", () => {
         const result = getIntersectionRatio({top: 450, height: 100}, 400, rootMargin);
-        expect(result).to.equal(1);
+        expect(result).to.equal(0.5);
       });
 
       it("returns 0 when above window with margins", () => {
@@ -193,14 +193,14 @@ describe("Intersection Calc", () => {
         expect(result).to.equal(1);
       });
 
-      it("returns 1 when partially inside window with margins (above)", () => {
-        const result = getIntersectionRatio({top: 50, height: 100}, 400, rootMargin);
-        expect(result).to.equal(1);
+      it("returns 0.5 when partially inside window with margins (above)", () => {
+        const result = getIntersectionRatio({top: -50, height: 100}, 400, rootMargin);
+        expect(result).to.equal(0.5);
       });
 
-      it("returns 1 when partially inside window with margins (below)", () => {
+      it("returns 0.5 when partially inside window with margins (below)", () => {
         const result = getIntersectionRatio({top: 250, height: 100}, 400, rootMargin);
-        expect(result).to.equal(1);
+        expect(result).to.equal(0.5);
       });
 
       it("returns 0 when above window with margins", () => {

--- a/test/intersection-observer-test.js
+++ b/test/intersection-observer-test.js
@@ -43,4 +43,83 @@ describe("IntersectionObserver", () => {
 
     expect(browser.document.getElementsByTagName("img")[1].src).to.be.ok;
   });
+
+  it("calls viewPortUpdate with correct element when observing new elements", async () => {
+    const browser = await Browser(app).navigateTo("/");
+    const [element1] = browser.document.getElementsByClassName("observer-test-1");
+    const [element2] = browser.document.getElementsByClassName("observer-test-2");
+
+    browser.window.IntersectionObserver = IntersectionObserver(browser);
+    let intersectingEntries = [];
+
+    const observer = browser.window.IntersectionObserver((entries) => {
+      intersectingEntries = entries.slice();
+    });
+
+    observer.observe(element1);
+
+    expect(intersectingEntries).to.have.length(1);
+    expect(intersectingEntries[0]).to.have.property("target", element1);
+
+    observer.observe(element2);
+
+    expect(intersectingEntries).to.have.length(1);
+    expect(intersectingEntries[0]).to.have.property("target", element2);
+  });
+
+  it("calls viewPortUpdate with correct element when scrolling", async () => {
+    const browser = await Browser(app).navigateTo("/");
+    browser.window._resize(1024, 768);
+    const [element1] = browser.document.getElementsByClassName("observer-test-1");
+    const [element2] = browser.document.getElementsByClassName("observer-test-2");
+
+    element1._setBoundingClientRect({ top: 200, bottom: 300 });
+    element2._setBoundingClientRect({ top: 400, bottom: 500 });
+
+    browser.setElementsToScroll(() => [element1, element2]);
+
+    browser.window.IntersectionObserver = IntersectionObserver(browser);
+    let intersectingEntries = [];
+    let timesCalled = 0;
+
+    const observer = browser.window.IntersectionObserver((entries) => {
+      intersectingEntries = entries.slice();
+      timesCalled++;
+    }, { rootMargin: "10px 0 10px" });
+
+    observer.observe(element1);
+    observer.observe(element2);
+    timesCalled = 0;
+    intersectingEntries.length = 0;
+
+    browser.scrollToTopOfElement(element1);
+
+    expect(timesCalled).to.equal(0);
+    expect(intersectingEntries).to.be.empty;
+
+    browser.scrollToTopOfElement(element1, -11);
+
+    expect(timesCalled).to.equal(1);
+    expect(intersectingEntries).to.have.length(1);
+    expect(intersectingEntries[0]).to.have.property("target", element1);
+
+    browser.scrollToTopOfElement(element2);
+    timesCalled = 0;
+    intersectingEntries.length = 0;
+
+    browser.scrollToTopOfElement(element2, -11);
+
+    expect(timesCalled).to.equal(1);
+    expect(intersectingEntries).to.have.length(1);
+    expect(intersectingEntries[0]).to.have.property("target", element2);
+
+    timesCalled = 0;
+    intersectingEntries.length = 0;
+
+    browser.scrollToTopOfElement(element1);
+    expect(timesCalled).to.equal(1);
+    expect(intersectingEntries).to.have.length(2);
+    expect(intersectingEntries[0]).to.have.property("target", element1);
+    expect(intersectingEntries[1]).to.have.property("target", element2);
+  });
 });


### PR DESCRIPTION
We have tested this in Solveig also, so we don't break anything.