### PR TITLE
Event listener improvements

### DIFF
--- a/lib/Element.js
+++ b/lib/Element.js
@@ -248,6 +248,7 @@ function Element(document, $elm) {
     function removeEventListener(name, fn, options) {
       const existingListenerIndex = getExistingIndex(name, fn, usesCapture(options));
       if (existingListenerIndex === -1) return;
+
       const existingListener = listeners[existingListenerIndex];
       const boundFn = existingListener[3];
 
@@ -256,10 +257,11 @@ function Element(document, $elm) {
     }
 
     function usesCapture(options) {
-      if (!options) return false;
       if (typeof options === "object") {
         return !!options.capture;
       }
+
+      return !!options;
     }
 
     function getExistingIndex(...config) {

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -33,7 +33,6 @@ function Element(document, $elm) {
     $elm,
     _emitter: emitter,
     _setBoundingClientRect: setBoundingClientRect,
-    ...EventListeners(),
     appendChild,
     classList,
     click,
@@ -212,6 +211,8 @@ function Element(document, $elm) {
     };
   }
 
+  Object.assign(element, EventListeners(element));
+
   element._emitter.on("_insert", () => {
     if (element.parentElement) {
       element.parentElement._emitter.emit("_insert");
@@ -219,59 +220,6 @@ function Element(document, $elm) {
   });
 
   return element;
-
-  function EventListeners() {
-    const listeners = [];
-
-    return {
-      addEventListener,
-      removeEventListener
-    };
-
-    function addEventListener(name, fn, options) {
-      const config = [name, fn, usesCapture(options), boundFn];
-      const existingListenerIndex = getExistingIndex(...config);
-      if (existingListenerIndex !== -1) return;
-
-      listeners.push(config);
-      emitter.on(name, boundFn);
-
-      function boundFn(...args) {
-        fn.apply(element, args);
-
-        if (options && options.once) {
-          removeEventListener(name, fn);
-        }
-      }
-    }
-
-    function removeEventListener(name, fn, options) {
-      const existingListenerIndex = getExistingIndex(name, fn, usesCapture(options));
-      if (existingListenerIndex === -1) return;
-
-      const existingListener = listeners[existingListenerIndex];
-      const boundFn = existingListener[3];
-
-      emitter.removeListener(name, boundFn);
-      listeners.splice(existingListenerIndex, 1);
-    }
-
-    function usesCapture(options) {
-      if (typeof options === "object") {
-        return !!options.capture;
-      }
-
-      return !!options;
-    }
-
-    function getExistingIndex(...config) {
-      return listeners.findIndex((listener) => {
-        return listener[0] === config[0]
-          && listener[1] === config[1]
-          && listener[2] === config[2];
-      });
-    }
-  }
 
   function getFirstChildElement() {
     const firstChild = find("> :first-child");
@@ -594,5 +542,58 @@ function Dataset($elm) {
     const key = prop.replace(/[A-Z]/g, (g) => `-${g[0].toLowerCase()}`);
     $elm.attr(`data-${key}`, value);
     return true;
+  }
+}
+
+function EventListeners(element) {
+  const listeners = [];
+
+  return {
+    addEventListener,
+    removeEventListener
+  };
+
+  function addEventListener(name, fn, options) {
+    const config = [name, fn, usesCapture(options), boundFn];
+    const existingListenerIndex = getExistingIndex(...config);
+    if (existingListenerIndex !== -1) return;
+
+    listeners.push(config);
+    element._emitter.on(name, boundFn);
+
+    function boundFn(...args) {
+      fn.apply(element, args);
+
+      if (options && options.once) {
+        removeEventListener(name, fn);
+      }
+    }
+  }
+
+  function removeEventListener(name, fn, options) {
+    const existingListenerIndex = getExistingIndex(name, fn, usesCapture(options));
+    if (existingListenerIndex === -1) return;
+
+    const existingListener = listeners[existingListenerIndex];
+    const boundFn = existingListener[3];
+
+    element._emitter.removeListener(name, boundFn);
+    listeners.splice(existingListenerIndex, 1);
+  }
+
+  function usesCapture(options) {
+    if (typeof options === "object") {
+      return !!options.capture;
+    }
+
+    return !!options;
+  }
+
+  function getExistingIndex(...config) {
+    return listeners.findIndex((listener) => {
+      return listener[0] === config[0]
+        && listener[1] === config[1]
+        && listener[2] === config[2];
+    });
   }
 }

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -25,14 +25,13 @@ function Element(document, $elm) {
   rects.bottom = rects.top + rects.height;
 
   const emitter = new EventEmitter();
-  const listenEvents = [];
+  const eventListeners = {};
 
   const classList = getClassList();
 
   const element = {
     $elm,
     _emitter: emitter,
-    _listenEvents: listenEvents,
     _setBoundingClientRect: setBoundingClientRect,
     addEventListener,
     appendChild,
@@ -222,17 +221,34 @@ function Element(document, $elm) {
 
   return element;
 
-  function addEventListener(eventName, fn) {
-    listenEvents.push(eventName);
-    emitter.on(eventName, fn);
+  function addEventListener(eventName, fn, options) {
+    let eventListenersByEvent = eventListeners[eventName];
+
+    if (!eventListenersByEvent) {
+      eventListeners[eventName] = eventListenersByEvent = new Map();
+    }
+
+    eventListenersByEvent.set(fn, boundFn);
+    emitter.on(eventName, boundFn);
+
+    function boundFn(...args) {
+      fn.apply(element, args);
+
+      if (options && options.once) {
+        removeEventListener(eventName, fn);
+      }
+    }
   }
 
   function removeEventListener(eventName, fn) {
-    const index = listenEvents.indexOf(eventName);
-    if (index > -1) {
-      listenEvents.splice(index, 1);
-    }
-    emitter.removeListener(eventName, fn);
+    const eventListenersByEvent = eventListeners[eventName];
+    if (!eventListenersByEvent) return;
+
+    const boundFn = eventListenersByEvent.get(fn);
+    if (!boundFn) return;
+
+    emitter.removeListener(eventName, boundFn);
+    eventListenersByEvent.delete(fn);
   }
 
   function getFirstChildElement() {

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -25,7 +25,7 @@ function Element(document, $elm) {
   rects.bottom = rects.top + rects.height;
 
   const emitter = new EventEmitter();
-  const eventListeners = {};
+
 
   const classList = getClassList();
 
@@ -33,7 +33,7 @@ function Element(document, $elm) {
     $elm,
     _emitter: emitter,
     _setBoundingClientRect: setBoundingClientRect,
-    addEventListener,
+    ...EventListeners(),
     appendChild,
     classList,
     click,
@@ -49,7 +49,6 @@ function Element(document, $elm) {
     remove,
     removeAttribute,
     removeChild,
-    removeEventListener,
     setAttribute,
     style: getStyle(),
   };
@@ -221,34 +220,55 @@ function Element(document, $elm) {
 
   return element;
 
-  function addEventListener(eventName, fn, options) {
-    let eventListenersByEvent = eventListeners[eventName];
+  function EventListeners() {
+    const listeners = [];
 
-    if (!eventListenersByEvent) {
-      eventListeners[eventName] = eventListenersByEvent = new Map();
-    }
+    return {
+      addEventListener,
+      removeEventListener
+    };
 
-    eventListenersByEvent.set(fn, boundFn);
-    emitter.on(eventName, boundFn);
+    function addEventListener(name, fn, options) {
+      const config = [name, fn, usesCapture(options), boundFn];
+      const existingListenerIndex = getExistingIndex(...config);
+      if (existingListenerIndex !== -1) return;
 
-    function boundFn(...args) {
-      fn.apply(element, args);
+      listeners.push(config);
+      emitter.on(name, boundFn);
 
-      if (options && options.once) {
-        removeEventListener(eventName, fn);
+      function boundFn(...args) {
+        fn.apply(element, args);
+
+        if (options && options.once) {
+          removeEventListener(name, fn);
+        }
       }
     }
-  }
 
-  function removeEventListener(eventName, fn) {
-    const eventListenersByEvent = eventListeners[eventName];
-    if (!eventListenersByEvent) return;
+    function removeEventListener(name, fn, options) {
+      const existingListenerIndex = getExistingIndex(name, fn, usesCapture(options));
+      if (existingListenerIndex === -1) return;
+      const existingListener = listeners[existingListenerIndex];
+      const boundFn = existingListener[3];
 
-    const boundFn = eventListenersByEvent.get(fn);
-    if (!boundFn) return;
+      emitter.removeListener(name, boundFn);
+      listeners.splice(existingListenerIndex, 1);
+    }
 
-    emitter.removeListener(eventName, boundFn);
-    eventListenersByEvent.delete(fn);
+    function usesCapture(options) {
+      if (!options) return false;
+      if (typeof options === "object") {
+        return !!options.capture;
+      }
+    }
+
+    function getExistingIndex(...config) {
+      return listeners.findIndex((listener) => {
+        return listener[0] === config[0]
+          && listener[1] === config[1]
+          && listener[2] === config[2];
+      });
+    }
   }
 
   function getFirstChildElement() {

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -904,6 +904,7 @@ describe("elements", () => {
 
   describe("Event listeners", () => {
     let buttons;
+    let clickCount;
     beforeEach(() => {
       const document = Document({
         text: `<html>
@@ -912,10 +913,10 @@ describe("elements", () => {
           </html>`
       });
       buttons = document.getElementsByTagName("button");
+      clickCount = 0;
     });
 
     it("listens to event", () => {
-      let clickCount = 0;
       buttons[0].addEventListener("click", increment);
 
       buttons[0].click();
@@ -927,14 +928,9 @@ describe("elements", () => {
       buttons[0].removeEventListener("click", increment);
       buttons[0].click();
       expect(clickCount).to.equal(2);
-
-      function increment() {
-        ++clickCount;
-      }
     });
 
     it("listens to event once", () => {
-      let clickCount = 0;
       buttons[0].addEventListener("click", increment, {once: true});
 
       buttons[0].click();
@@ -942,15 +938,9 @@ describe("elements", () => {
 
       buttons[0].click();
       expect(clickCount).to.equal(1);
-
-      function increment() {
-        ++clickCount;
-      }
     });
 
     it("event listeners are invoked with element as this", () => {
-      let clickCount = 0;
-
       buttons[0].addEventListener("click", increment);
       buttons[1].addEventListener("click", increment);
 
@@ -961,11 +951,27 @@ describe("elements", () => {
       expect(clickCount).to.equal(3);
       expect(buttons[0].clickCount).to.equal(2);
       expect(buttons[1].clickCount).to.equal(1);
-
-      function increment() {
-        ++clickCount;
-        this.clickCount = !this.clickCount ? 1 : this.clickCount + 1;
-      }
     });
+
+    describe("listener is 'identical' based on eventName, callback and useCapture", () => {
+      it("disregards multiple 'identical' event listeners", () => {
+        buttons[0].addEventListener("click", increment);
+        buttons[0].addEventListener("click", increment, false);
+        buttons[0].addEventListener("click", increment, {capture: false});
+        buttons[0].addEventListener("click", increment, {passive: true});
+
+        buttons[0].click();
+        expect(clickCount).to.equal(1);
+
+        buttons[0].removeEventListener("click", increment);
+        buttons[0].click();
+        expect(clickCount).to.equal(1);
+      });
+    });
+
+    function increment() {
+      ++clickCount;
+      this.clickCount = !this.clickCount ? 1 : this.clickCount + 1;
+    }
   });
 });

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -901,4 +901,71 @@ describe("elements", () => {
       expect(returnValue).to.eql(newNode);
     });
   });
+
+  describe("Event listeners", () => {
+    let buttons;
+    beforeEach(() => {
+      const document = Document({
+        text: `<html>
+            <button id="button-1" type="button"></button>
+            <button id="button-2" type="button"></button>
+          </html>`
+      });
+      buttons = document.getElementsByTagName("button");
+    });
+
+    it("listens to event", () => {
+      let clickCount = 0;
+      buttons[0].addEventListener("click", increment);
+
+      buttons[0].click();
+      expect(clickCount).to.equal(1);
+
+      buttons[0].click();
+      expect(clickCount).to.equal(2);
+
+      buttons[0].removeEventListener("click", increment);
+      buttons[0].click();
+      expect(clickCount).to.equal(2);
+
+      function increment() {
+        ++clickCount;
+      }
+    });
+
+    it("listens to event once", () => {
+      let clickCount = 0;
+      buttons[0].addEventListener("click", increment, {once: true});
+
+      buttons[0].click();
+      expect(clickCount).to.equal(1);
+
+      buttons[0].click();
+      expect(clickCount).to.equal(1);
+
+      function increment() {
+        ++clickCount;
+      }
+    });
+
+    it("event listeners are invoked with element as this", () => {
+      let clickCount = 0;
+
+      buttons[0].addEventListener("click", increment);
+      buttons[1].addEventListener("click", increment);
+
+      buttons[0].click();
+      buttons[0].click();
+      buttons[1].click();
+
+      expect(clickCount).to.equal(3);
+      expect(buttons[0].clickCount).to.equal(2);
+      expect(buttons[1].clickCount).to.equal(1);
+
+      function increment() {
+        ++clickCount;
+        this.clickCount = !this.clickCount ? 1 : this.clickCount + 1;
+      }
+    });
+  });
 });

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -974,6 +974,29 @@ describe("elements", () => {
         buttons[0].click();
         expect(clickCount).to.equal(3);
       });
+
+      it("multiple listeners with different once option", () => {
+        buttons[0].addEventListener("click", increment, {once: false});
+        buttons[0].addEventListener("click", increment, {once: true}); // won't be once
+
+        buttons[1].addEventListener("click", increment, {once: true});
+        buttons[1].addEventListener("click", increment, {once: false}); // will be once
+
+        buttons[0].click();
+        buttons[0].click();
+        expect(clickCount).to.equal(2);
+
+        buttons[1].click();
+        buttons[1].click();
+        expect(clickCount).to.equal(3);
+
+        buttons[0].removeEventListener("click", increment);
+        buttons[1].removeEventListener("click", increment);
+
+        buttons[0].click();
+        buttons[1].click();
+        expect(clickCount).to.equal(3);
+      });
     });
 
     function increment() {

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -960,12 +960,19 @@ describe("elements", () => {
         buttons[0].addEventListener("click", increment, {capture: false});
         buttons[0].addEventListener("click", increment, {passive: true});
 
+        buttons[0].addEventListener("click", increment, true);
+        buttons[0].addEventListener("click", increment, {capture: true});
+
         buttons[0].click();
-        expect(clickCount).to.equal(1);
+        expect(clickCount).to.equal(2);
 
         buttons[0].removeEventListener("click", increment);
         buttons[0].click();
-        expect(clickCount).to.equal(1);
+        expect(clickCount).to.equal(3);
+
+        buttons[0].removeEventListener("click", increment, true);
+        buttons[0].click();
+        expect(clickCount).to.equal(3);
       });
     });
 


### PR DESCRIPTION
- Adds support for the event listener `once` option
- Callback gets invoked with element as `this` 
- Correctly adds and removes listeners
- Drops the `element._listenEvents` property.