### PR TITLE
fix/element._setBoundingClientRect

### DIFF
--- a/lib/Element.js
+++ b/lib/Element.js
@@ -415,7 +415,7 @@ function Element(document, $elm) {
   }
 
   function setBoundingClientRect(axes) {
-    if (!axes.bottom) {
+    if (!("bottom" in axes)) {
       axes.bottom = axes.top;
     }
 

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -392,11 +392,11 @@ describe("elements", () => {
 
     it("sets offsetHeight as well", () => {
       const [elm] = document.getElementsByTagName("p");
-      elm._setBoundingClientRect({
-        top: 10, bottom: 200
-      });
-
+      elm._setBoundingClientRect({top: 10, bottom: 200});
       expect(elm.offsetHeight).to.equal(190);
+
+      elm._setBoundingClientRect({top: -300, bottom: 0});
+      expect(elm.offsetHeight).to.equal(300);
     });
   });
 


### PR DESCRIPTION
Solves bug where scrolling to point where element bottom coord is 0 caused height to disappear