### PR TITLE
Reset form / multi select / checkbox

### DIFF
--- a/lib/Element.js
+++ b/lib/Element.js
@@ -110,23 +110,6 @@ function Element(document, $elm) {
     }
   });
 
-  Object.defineProperty(element, "options", {
-    get: () => getChildren("option")
-  });
-
-  Object.defineProperty(element, "selected", {
-    get: () => getAttribute("selected"),
-    set: (val) => {
-      $elm.siblings("option").removeAttr("selected");
-      setAttribute("selected", val);
-      return val;
-    }
-  });
-
-  Object.defineProperty(element, "selectedIndex", {
-    get: () => getChildren("option").findIndex((option) => option.selected)
-  });
-
   Object.defineProperty(element, "innerText", {
     get: () => element.textContent,
     set: (value) => {
@@ -194,26 +177,48 @@ function Element(document, $elm) {
   }
 
   function checkboxChecked(value) {
-    const oldValue = (getAttribute("checked") === "checked");
+    const oldValue = getProperty("checked");
 
-    if (value) {
-      setAttribute("checked", "checked");
-    } else {
-      removeAttribute("checked");
-    }
+    setProperty("checked", value);
+
     if (value !== oldValue) {
       dispatchEvent(new CustomEvent("change"));
     }
   }
 
   Object.defineProperty(element, "checked", {
-    get: () => {
-      return getAttribute("checked") === "checked";
-    },
+    get: () => getProperty("checked"),
     set: (value) => {
       if ($elm.attr("type") === "radio") radioButtonChecked(value);
       else if ($elm.attr("type") === "checkbox") checkboxChecked(value);
     }
+  });
+
+  Object.defineProperty(element, "options", {
+    get: () => getChildren("option")
+  });
+
+  Object.defineProperty(element, "selected", {
+    get: () => getProperty("selected"),
+    set: (value) => {
+      const oldValue = getProperty("selected");
+      const $select = $elm.parent("select");
+      if (!$select.attr("multiple")) {
+        if (value) $elm.siblings("option").prop("selected", false);
+      }
+
+      setProperty("selected", value);
+
+      if (value !== oldValue) {
+        _getElement($select).dispatchEvent(new CustomEvent("change"));
+      }
+
+      return value;
+    }
+  });
+
+  Object.defineProperty(element, "selectedIndex", {
+    get: () => getChildren("option").findIndex((option) => option.selected)
   });
 
   Object.defineProperty(element, "disabled", {
@@ -253,6 +258,7 @@ function Element(document, $elm) {
 
   if (tagName === "form") {
     element.submit = submit;
+    element.reset = reset;
   }
 
   if (tagName === "video") {
@@ -344,6 +350,7 @@ function Element(document, $elm) {
 
     if (!clickEvent.defaultPrevented && element.form) {
       if (element.type === "submit") element.form.submit();
+      else if (element.type === "reset") element.form.reset();
     }
   }
 
@@ -370,6 +377,14 @@ function Element(document, $elm) {
 
   function hasAttribute(name) {
     return $elm.is(`[${name}]`);
+  }
+
+  function getProperty(name) {
+    return $elm.prop(name);
+  }
+
+  function setProperty(name, val) {
+    return $elm.prop(name, val);
   }
 
   function removeChild(childElement) {
@@ -500,6 +515,25 @@ function Element(document, $elm) {
 
   function submit() {
     dispatchEvent(new CustomEvent("submit"));
+  }
+
+  function reset() {
+    const $inputs = find("input[type='checkbox']");
+    if ($inputs.length) {
+      $inputs.each((idx, elm) => {
+        $(elm).prop("checked", !!$(elm).attr("checked"));
+      });
+    }
+
+    const $options = find("option");
+    if ($options.length) {
+      $options.each((idx, elm) => {
+        $(elm).prop("selected", !!$(elm).attr("selected"));
+        $(elm).prop("selected");
+      });
+    }
+
+    dispatchEvent(new CustomEvent("reset"));
   }
 
   function getClassList() {

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -181,20 +181,38 @@ function Element(document, $elm) {
     }
   });
 
+  function radioButtonChecked(value) {
+    const oldValue = (getAttribute("checked") === "checked");
+    uncheckRadioButtons();
+
+    if (value) {
+      setAttribute("checked", "checked");
+      if (!oldValue) {
+        dispatchEvent(new CustomEvent("change"));
+      }
+    }
+  }
+
+  function checkboxChecked(value) {
+    const oldValue = (getAttribute("checked") === "checked");
+
+    if (value) {
+      setAttribute("checked", "checked");
+    } else {
+      removeAttribute("checked");
+    }
+    if (value !== oldValue) {
+      dispatchEvent(new CustomEvent("change"));
+    }
+  }
+
   Object.defineProperty(element, "checked", {
     get: () => {
       return getAttribute("checked") === "checked";
     },
     set: (value) => {
-      const oldValue = (getAttribute("checked") === "checked");
-      uncheckRadioButtons();
-
-      if (value) {
-        setAttribute("checked", "checked");
-        if (!oldValue) {
-          dispatchEvent(new CustomEvent("change"));
-        }
-      }
+      if ($elm.attr("type") === "radio") radioButtonChecked(value);
+      else if ($elm.attr("type") === "checkbox") checkboxChecked(value);
     }
   });
 

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -341,6 +341,70 @@ describe("elements", () => {
     });
   });
 
+  describe("input[type=checkbox]", () => {
+    let document;
+    beforeEach(() => {
+      document = Document({
+        text: `
+          <html>
+            <body>
+              <input type="checkbox" name="test" value="1" checked="checked">
+              <input type="checkbox" name="test" value="2">
+            </body>
+          </html>`
+      });
+    });
+
+    it("has checked true if checked", () => {
+      expect(document.getElementsByTagName("input")[0].checked).to.be.true;
+    });
+
+    it("has checked false if not checked", () => {
+      expect(document.getElementsByTagName("input")[1].checked).to.be.false;
+    });
+
+    it("has value", () => {
+      expect(document.getElementsByTagName("input")[0].value).to.equal("1");
+      expect(document.getElementsByTagName("input")[1].value).to.equal("2");
+    });
+
+    it("can set checked", () => {
+      const elm = document.getElementsByTagName("input")[1];
+      elm.checked = true;
+      expect(elm.checked).to.be.true;
+    });
+
+    it("can set unchecked", () => {
+      const elm = document.getElementsByTagName("input")[0];
+      elm.checked = false;
+      expect(elm.checked).to.be.false;
+    });
+
+    it("emits change when checked", () => {
+      const elm = document.getElementsByTagName("input")[1];
+      let result = 0;
+      elm.addEventListener("change", () => (result = 1));
+      elm.checked = true;
+      expect(result).to.equal(1);
+    });
+
+    it("emits change when unchecked", () => {
+      const elm = document.getElementsByTagName("input")[0];
+      let result = 0;
+      elm.addEventListener("change", () => (result = 1));
+      elm.checked = false;
+      expect(result).to.equal(1);
+    });
+
+    it("emits no change when state is unchanged", () => {
+      const elm = document.getElementsByTagName("input")[0];
+      let result = 0;
+      elm.addEventListener("change", () => (result = 1));
+      elm.checked = true;
+      expect(result).to.equal(0);
+    });
+  });
+
   describe("_setBoundingClientRect", () => {
     let document;
     beforeEach(() => {

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -383,7 +383,7 @@ describe("elements", () => {
     it("emits change when checked", () => {
       const elm = document.getElementsByTagName("input")[1];
       let result = 0;
-      elm.addEventListener("change", () => (result = 1));
+      elm.addEventListener("change", () => (result++));
       elm.checked = true;
       expect(result).to.equal(1);
     });
@@ -391,7 +391,7 @@ describe("elements", () => {
     it("emits change when unchecked", () => {
       const elm = document.getElementsByTagName("input")[0];
       let result = 0;
-      elm.addEventListener("change", () => (result = 1));
+      elm.addEventListener("change", () => (result++));
       elm.checked = false;
       expect(result).to.equal(1);
     });
@@ -399,7 +399,7 @@ describe("elements", () => {
     it("emits no change when state is unchanged", () => {
       const elm = document.getElementsByTagName("input")[0];
       let result = 0;
-      elm.addEventListener("change", () => (result = 1));
+      elm.addEventListener("change", () => (result++));
       elm.checked = true;
       expect(result).to.equal(0);
     });

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -880,11 +880,14 @@ describe("elements", () => {
             <body>
               <h2>Test <b>title</b></h2>
               <form id="get-form" type="get" action="/">
+                <input type="checkbox" value="1">
+                <input type="checkbox" value="2" checked="checked">
                 <select>
                   <option value="1">1</option>
-                  <option value="2" selected>2</option>
+                  <option value="2" selected="selected">2</option>
                 </select>
                 <button type="submit">Submit</submit>
+                <button type="reset">Submit</submit>
               </form>
             </body>
           </html>`
@@ -893,6 +896,10 @@ describe("elements", () => {
 
     it("has submit method", () => {
       expect(document.getElementById("get-form")).to.have.property("submit").that.is.a("function");
+    });
+
+    it("has reset method", () => {
+      expect(document.getElementById("get-form")).to.have.property("reset").that.is.a("function");
     });
 
     it("submit button has associated form property", () => {
@@ -910,6 +917,15 @@ describe("elements", () => {
       button.click();
     });
 
+    it("submit button click emits submit on form", (done) => {
+      const [form] = document.getElementsByTagName("form");
+      const [button] = document.getElementsByTagName("button");
+
+      form.addEventListener("submit", () => done());
+
+      button.click();
+    });
+
     it("submit sets event target to form", (done) => {
       const [form] = document.getElementsByTagName("form");
       const [button] = document.getElementsByTagName("button");
@@ -922,9 +938,57 @@ describe("elements", () => {
       button.click();
     });
 
-    it("returns options in select", () => {
+    it("reset button click emits reset on form", (done) => {
+      const [form] = document.getElementsByTagName("form");
+      const [, button] = form.getElementsByTagName("button");
+
+      form.addEventListener("reset", () => done());
+
+      button.click();
+    });
+
+    it("reset form resets form elements", () => {
       const [form] = document.getElementsByTagName("form");
       const [select] = form.getElementsByTagName("select");
+      const checkboxes = form.getElementsByTagName("input[type='checkbox']");
+
+      select.options[0].selected = true;
+
+      checkboxes[0].checked = true;
+      checkboxes[1].checked = false;
+
+      form.reset();
+
+      expect(select.options[0].selected).to.be.false;
+      expect(select.options[1].selected).to.be.true;
+
+      expect(checkboxes[0].checked).to.be.false;
+      expect(checkboxes[1].checked).to.be.true;
+    });
+  });
+
+  describe("select", () => {
+    let document;
+    beforeEach(() => {
+      document = Document({
+        text: `
+          <html>
+            <body>
+              <select>
+                <option value="1">1</option>
+                <option value="2" selected="selected">2</option>
+              </select>
+              <select multiple="multiple">
+                <option value="1">1</option>
+                <option value="2" selected="selected">2</option>
+              </select>
+            </body>
+          </html>`
+      });
+    });
+
+    it("returns options in select", () => {
+      const [select] = document.getElementsByTagName("select");
       const options = select.getElementsByTagName("option");
 
       expect(select.options.length).to.equal(2);
@@ -933,20 +997,36 @@ describe("elements", () => {
     });
 
     it("returns selected index of options in select", () => {
-      const [form] = document.getElementsByTagName("form");
-      const [select] = form.getElementsByTagName("select");
+      const [select] = document.getElementsByTagName("select");
 
       expect(select.selectedIndex).to.equal(1);
     });
 
     it("should change selected index when changing selected option", () => {
-      const [form] = document.getElementsByTagName("form");
-      const [select] = form.getElementsByTagName("select");
+      const [select] = document.getElementsByTagName("select");
 
-      select.options[0].selected = "selected";
+      select.options[0].selected = true;
 
       expect(select.selectedIndex).to.equal(0);
-      expect(select.$elm.find("[selected]").length).to.equal(1);
+      expect(select.options[0].selected).to.be.true;
+      expect(select.options[1].selected).to.be.false;
+    });
+
+    it("should not de-select other options when selecting in multiple select", () => {
+      const [, select] = document.getElementsByTagName("select");
+
+      select.options[0].selected = true;
+
+      expect(select.options[0].selected).to.be.true;
+      expect(select.options[1].selected).to.be.true;
+    });
+
+    it("should emit change on select when changing selected option", (done) => {
+      const [select] = document.getElementsByTagName("select");
+
+      select.addEventListener("change", () => done());
+
+      select.options[0].selected = true;
     });
   });
 


### PR DESCRIPTION
~~Merge after #47.~~ Closed the PR instead.

This adds support for `<input type="checkbox">`, `.reset()` on forms as well as `<select multiple>` elements.

I also cleaned up a bit in the checkbox department. The important part here is that selects and checkboxes no longer use their respective attributes when checking if they're checked/selected, instead they use the internal properties instead. This is similar to how jQuery uses `.prop()` and `.attr()` differently to differentiate these two.
http://blog.jquery.com/2011/05/12/jquery-1-6-1-released/

I didn't change anything about radio buttons because of not wanting to break existing functionality but this behaviour should probably be mirrored as well.