### PR TITLE
More robust handling of cookie header parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function Tallahassee(app) {
   function navigateTo(linkUrl, headers = {}, statusCode = 200) {
     for (const key in headers) {
       if (key.toLowerCase() === "cookie") {
-        agent.jar.setCookies(headers[key].split(";").filter((cookie) => cookie));
+        agent.jar.setCookies(headers[key].split(";").map((c) => c.trim()).filter(Boolean));
       }
     }
     const req = agent.get(linkUrl);

--- a/test/index.js
+++ b/test/index.js
@@ -102,6 +102,22 @@ describe("Tallahassee", () => {
 
       expect(browser.document).to.have.property("cookie", "_ga=13");
     });
+
+    it("sets multiple cookies on document", async () => {
+      const browser = await Browser(app).navigateTo("/", {
+        cookie: "cookie1=abc;cookie2=def"
+      });
+
+      expect(browser.document).to.have.property("cookie", "cookie1=abc;cookie2=def");
+    });
+
+    it("sets multiple cookies on document disregarding whitespace and empty values", async () => {
+      const browser = await Browser(app).navigateTo("/", {
+        cookie: " cookie1=abc; cookie2=def; ;   ;\tcookie3=ghi;; ;   ;"
+      });
+
+      expect(browser.document).to.have.property("cookie", "cookie1=abc;cookie2=def;cookie3=ghi");
+    });
   });
 
   describe("window", () => {


### PR DESCRIPTION
Since we have several tests with multiple cookies containing space in between, this will help us.