### PR TITLE
Added functionality to scroll within element.

### DIFF
--- a/lib/Element.js
+++ b/lib/Element.js
@@ -53,6 +53,7 @@ function Element(document, $elm) {
     removeChild,
     requestFullscreen,
     setAttribute,
+    setElementsToScroll,
     cloneNode,
     style: getStyle(),
   };
@@ -244,6 +245,10 @@ function Element(document, $elm) {
     get: () => _getElement($elm.closest("form"))
   });
 
+  Object.defineProperty(element, "offsetWidth", {
+    get: () => getBoundingClientRect().width
+  });
+
   Object.defineProperty(element, "offsetHeight", {
     get: () => getBoundingClientRect().height
   });
@@ -255,6 +260,50 @@ function Element(document, $elm) {
   Object.defineProperty(element, "nodeType", {
     get: () => 1
   });
+
+  Object.defineProperty(element, "scrollWidth", {
+    get: () => {
+      return element.children.reduce((acc, el) => {
+        acc += el.getBoundingClientRect().width;
+        return acc;
+      }, 0);
+    }
+  });
+
+  let currentScrollLeft = 0;
+  Object.defineProperty(element, "scrollLeft", {
+    get: () => currentScrollLeft,
+    set: (value) => {
+      const scrollWidth = element.scrollWidth;
+      if (value > scrollWidth) value = scrollWidth;
+      else if (value < 0) value = 0;
+
+      onElementScroll(value);
+      currentScrollLeft = value;
+      dispatchEvent(new CustomEvent("scroll"));
+    }
+  });
+
+  let elementsToScroll = () => {};
+  function setElementsToScroll(elmsToScrollFn) {
+    elementsToScroll = elmsToScrollFn;
+  }
+
+  function onElementScroll(scrollLeft) {
+    if (!elementsToScroll) return;
+    const elms = elementsToScroll(document);
+    if (!elms || !elms.length) return;
+
+    const delta = currentScrollLeft - scrollLeft;
+
+    elms.slice().forEach((elm) => {
+      const {left, right} = elm.getBoundingClientRect();
+      elm._setBoundingClientRect({
+        left: (left || 0) + delta,
+        right: (right || 0) + delta
+      });
+    });
+  }
 
   if (tagName === "form") {
     element.submit = submit;
@@ -459,7 +508,9 @@ function Element(document, $elm) {
     }
 
     for (const axis in axes) {
-      rects[axis] = axes[axis];
+      if (axes.hasOwnProperty(axis)) {
+        rects[axis] = axes[axis];
+      }
     }
 
     rects.height = rects.bottom - rects.top;

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -462,6 +462,15 @@ describe("elements", () => {
       elm._setBoundingClientRect({top: -300, bottom: 0});
       expect(elm.offsetHeight).to.equal(300);
     });
+
+    it("sets offsetWidth as well", () => {
+      const [elm] = document.getElementsByTagName("p");
+      elm._setBoundingClientRect({left: 10, right: 200});
+      expect(elm.offsetWidth).to.equal(190);
+
+      elm._setBoundingClientRect({left: -300, right: 0});
+      expect(elm.offsetWidth).to.equal(300);
+    });
   });
 
   describe(".textContent", () => {
@@ -1567,6 +1576,54 @@ describe("elements", () => {
       element10.requestFullscreen();
 
       expect(document.fullscreenElement).to.eql(element10);
+    });
+  });
+
+  describe("scrollLeft", () => {
+    let document;
+    beforeEach(() => {
+      document = Document({
+        text: `
+          <html>
+            <body>
+              <div class="element">
+                <div></div>
+              </div>
+            </body>
+          </html>`
+      });
+      const element = document.getElementsByClassName("element")[0];
+      element._setBoundingClientRect({
+        left: 0,
+        right: 100
+      });
+
+      element.firstElementChild._setBoundingClientRect({
+        left: 0,
+        right: 200
+      });
+    });
+
+    it("should get element x-axis scroll value", () => {
+      const element = document.getElementsByClassName("element")[0];
+
+      expect(element.scrollLeft).to.equal(0);
+    });
+
+    it("should set element x-axis scroll value", () => {
+      const element = document.getElementsByClassName("element")[0];
+      element.scrollLeft = 10;
+
+      expect(element.scrollLeft).to.equal(10);
+    });
+
+    it("should affect other elements inside", () => {
+      const element = document.getElementsByClassName("element")[0];
+      const child = element.firstElementChild;
+      element.setElementsToScroll(() => [child]);
+      element.scrollLeft = 10;
+
+      expect(child.getBoundingClientRect().left).to.equal(-10);
     });
   });
 });


### PR DESCRIPTION
Might break backwards compatibility because of `offsetWidth` not being able to be set manually any longer. Use `_setBoundingClientRect()` instead.