### PR TITLE
use default header to match if redirect hits local app

### DIFF
--- a/API.md
+++ b/API.md
@@ -17,6 +17,14 @@
 
 <!-- tocstop -->
 
+# `Tallahassee(app[, options])`
+
+Create new instance of Tallahasse.
+
+- `app`: required express app
+- `options`: optional options
+  - `headers`: default headers for local trafic
+
 # `navigateTo(route[, headers, expectedStatusCode])`
 
 Navigate to route.

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const assert = require("assert");
 
 module.exports = Tallahassee;
 
-function Tallahassee(app) {
+function Tallahassee(app, options = {}) {
   const agent = supertest.agent(app);
   return {
     navigateTo,
@@ -21,6 +21,13 @@ function Tallahassee(app) {
   };
 
   function navigateTo(linkUrl, headers = {}, statusCode = 200) {
+    if (options.headers) {
+      headers = {
+        ...options.headers,
+        ...headers,
+      };
+    }
+
     let numRedirects = 0;
     for (const key in headers) {
       if (key.toLowerCase() === "cookie") {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expressen/tallahassee",
-  "version": "8.0.2",
+  "version": "8.1.0",
   "description": "Expressen client testing framework",
   "main": "index.js",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Added default headers to be able to match an external redirect that redirects back to app. 