### PR TITLE
IntersectionObserverEntry

### DIFF
--- a/lib/IntersectionObserver.js
+++ b/lib/IntersectionObserver.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const {getRootMargin, getIntersectionRatio} = require("./intersectionCalc");
+const IntersectionObserverEntry = require("./intersectionObserverEntry");
 
 module.exports = function FakeIntersectionObserver(browser) {
   const observed = [];
@@ -8,6 +9,10 @@ module.exports = function FakeIntersectionObserver(browser) {
   IntersectionObserver._getObserved = function () {
     return observed;
   };
+
+  const intersectionObserverEntry = IntersectionObserverEntry(browser);
+  intersectionObserverEntry.prototype.intersectionRatio = getIntersectionRatio;
+  browser.window.IntersectionObserverEntry = intersectionObserverEntry;
 
   return IntersectionObserver;
 
@@ -24,7 +29,7 @@ module.exports = function FakeIntersectionObserver(browser) {
       observe(element) {
         toObserve.push(element);
         observed.push(element);
-        const newEntries = [element].map(toEntry);
+        const newEntries = [element].map((el) => intersectionObserverEntry(el, rootMargin));
         viewPortUpdate(newEntries);
         previousEntries = previousEntries.concat(newEntries);
       },
@@ -37,7 +42,7 @@ module.exports = function FakeIntersectionObserver(browser) {
     };
 
     function onScroll() {
-      const entries = toObserve.map(toEntry);
+      const entries = toObserve.map((el) => intersectionObserverEntry(el, rootMargin));
       const changedEntries = entries.filter(hasChanged);
 
       if (changedEntries.length > 0) {
@@ -51,13 +56,6 @@ module.exports = function FakeIntersectionObserver(browser) {
       const previous = previousEntries.find((x) => x.target === entry.target);
       if (!previous) return true;
       return entry.intersectionRatio !== previous.intersectionRatio;
-    }
-
-    function toEntry(element) {
-      const boundingClientRect = element.getBoundingClientRect();
-      const intersectionRatio = getIntersectionRatio(boundingClientRect, browser.window.innerHeight, rootMargin);
-
-      return {target: element, boundingClientRect, intersectionRatio};
     }
   }
 };

--- a/lib/intersectionObserverEntry.js
+++ b/lib/intersectionObserverEntry.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const {getIntersectionRatio} = require("./intersectionCalc");
+
+module.exports = function FakeIntersectionObserverEntry(browser) {
+  return IntersectionObserverEntry;
+
+  function IntersectionObserverEntry(element, rootMargin) {
+    const boundingClientRect = element.getBoundingClientRect();
+    const intersectionRatio = getIntersectionRatio(boundingClientRect, browser.window.innerHeight, rootMargin);
+
+    return {target: element, boundingClientRect, intersectionRatio};
+  }
+};

--- a/test/intersection-observer-test.js
+++ b/test/intersection-observer-test.js
@@ -18,6 +18,8 @@ describe("IntersectionObserver", () => {
     require("../app/assets/scripts/main");
 
     expect(intersectionObserver._getObserved()).to.have.length(1);
+    expect(browser.window.IntersectionObserverEntry).to.exist;
+    expect(browser.window.IntersectionObserverEntry.prototype.intersectionRatio).to.exist;
   });
 
   it("listens to window scroll", async () => {


### PR DESCRIPTION
Added intersection observer entry method to be mocked in conjunction with intersection observer.

This is to prevent the [IntersectionObserver polyfill](https://github.com/w3c/IntersectionObserver/tree/master/polyfill) by W3C to overwrite a Tallahassee mock during tests by setting the necessary properties on `window`.