### PR TITLE
Now handles null properly as a reset value on style property.

### DIFF
--- a/lib/Element.js
+++ b/lib/Element.js
@@ -760,7 +760,7 @@ function Element(document, $elm) {
     const StyleHandler = {
       set: (target, name, value) => {
         if (!name) return false;
-        target[name] = value;
+        target[name] = handleResetValue(value);
         setStyle();
         return true;
       },
@@ -798,6 +798,11 @@ function Element(document, $elm) {
 
       if (!styleValue) return removeAttribute("style");
       setAttribute("style", styleValue);
+    }
+
+    function handleResetValue(value) {
+      if (value === "" || value === null) return "";
+      return value;
     }
   }
 }

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -246,6 +246,22 @@ describe("elements", () => {
       elm.style.marginTop = 0;
       expect(elm.outerHTML).to.equal("<h2 id=\"headline\" style=\"-ms-grid-columns: auto auto;margin-top: 0;\">Test</h2>");
     });
+
+    it("handles empty string as reset value", () => {
+      const [elm] = document.getElementsByTagName("img");
+      expect(elm.style.display).to.equal("none");
+
+      elm.style.display = "";
+      expect(elm.style.display).to.equal("");
+    });
+
+    it("handles null as reset value", () => {
+      const [elm] = document.getElementsByTagName("img");
+      expect(elm.style.display).to.equal("none");
+
+      elm.style.display = null;
+      expect(elm.style.display).to.equal("");
+    });
   });
 
   describe("api", () => {


### PR DESCRIPTION
> A style declaration is reset by setting it to null or an empty string, e.g., elt.style.color = null.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style