### PR TITLE
Support element.focus() unless element is disabled

### DIFF
--- a/lib/Element.js
+++ b/lib/Element.js
@@ -49,6 +49,7 @@ function Element(document, $elm) {
     closest,
     contains,
     dispatchEvent,
+    focus,
     getAttribute,
     getBoundingClientRect,
     getElementsByClassName(classNames) {
@@ -511,6 +512,12 @@ function Element(document, $elm) {
         element.form.reset();
       }
     }
+  }
+
+  function focus() {
+    if (element.disabled) return;
+    const focusEvent = new Event("focus", { bubbles: true });
+    dispatchEvent(focusEvent);
   }
 
   function contains(el) {

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -1829,6 +1829,14 @@ describe("elements", () => {
       buttons[0].removeEventListener("click", increment);
       buttons[0].click();
       expect(clickCount).to.equal(2);
+
+      let focusCount = 0;
+      buttons[0].addEventListener("focus", () => {
+        ++focusCount;
+        this.focusCount = !this.focusCount ? 1 : this.focusCount + 1;
+      });
+      buttons[0].focus();
+      expect(focusCount).to.equal(1);
     });
 
     it("listens to event once", () => {
@@ -1846,6 +1854,13 @@ describe("elements", () => {
       buttons[2].click();
 
       expect(clickCount).to.equal(0);
+
+      let focusCount = 0;
+      buttons[2].addEventListener("focus", () => {
+        ++focusCount;
+      });
+      buttons[2].focus();
+      expect(focusCount).to.equal(0);
     });
 
     it("event listeners are invoked with element as this", () => {

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -1816,8 +1816,26 @@ describe("elements", () => {
       buttons = document.getElementsByTagName("button");
       clickCount = 0;
     });
+    
+    it("listens to focus event", () => {
+      let focusCount = 0;
+      buttons[0].addEventListener("focus", () => {
+        ++focusCount;
+      });
+      buttons[0].focus();
+      expect(focusCount).to.equal(1);
+    });
+    
+    it("does not trigger focus event when the element is disabled", () => {
+      let focusCount = 0;
+      buttons[2].addEventListener("focus", () => {
+        ++focusCount;
+      });
+      buttons[2].focus();
+      expect(focusCount).to.equal(0);
+    });
 
-    it("listens to event", () => {
+    it("listens to click event", () => {
       buttons[0].addEventListener("click", increment);
 
       buttons[0].click();
@@ -1829,17 +1847,9 @@ describe("elements", () => {
       buttons[0].removeEventListener("click", increment);
       buttons[0].click();
       expect(clickCount).to.equal(2);
-
-      let focusCount = 0;
-      buttons[0].addEventListener("focus", () => {
-        ++focusCount;
-        this.focusCount = !this.focusCount ? 1 : this.focusCount + 1;
-      });
-      buttons[0].focus();
-      expect(focusCount).to.equal(1);
     });
 
-    it("listens to event once", () => {
+    it("listens to click event once", () => {
       buttons[0].addEventListener("click", increment, {once: true});
 
       buttons[0].click();
@@ -1848,22 +1858,15 @@ describe("elements", () => {
       buttons[0].click();
       expect(clickCount).to.equal(1);
     });
-
-    it("does not fire event when disabled", () => {
+    
+    it("does not fire event when the element is disabled", () => {
       buttons[2].addEventListener("click", increment);
       buttons[2].click();
 
       expect(clickCount).to.equal(0);
-
-      let focusCount = 0;
-      buttons[2].addEventListener("focus", () => {
-        ++focusCount;
-      });
-      buttons[2].focus();
-      expect(focusCount).to.equal(0);
     });
 
-    it("event listeners are invoked with element as this", () => {
+    it("can invoke click event listeners with element as this", () => {
       buttons[0].addEventListener("click", increment);
       buttons[1].addEventListener("click", increment);
 


### PR DESCRIPTION
Support `element.focus()`

The main purpose of this PR is to provide support for this method, to avoid tallahaasee throwing errors when testing code that uses this function.

The method itself doesn't need to do anything in particular, so all I had it do was to dispatch a "focus" event.