### PR TITLE
Batched, async call to intersection observer callback on observe

### DIFF
--- a/app/assets/public/index.html
+++ b/app/assets/public/index.html
@@ -86,5 +86,6 @@
     </script>
     <div class="observer-test-1">Test1</div>
     <div class="observer-test-2">Test2</div>
+    <div class="observer-test-3">Test3</div>
   </body>
 </html>

--- a/lib/IntersectionObserver.js
+++ b/lib/IntersectionObserver.js
@@ -22,17 +22,20 @@ module.exports = function FakeIntersectionObserver(browser) {
     const rootMargin = getRootMargin(options);
     browser.window.addEventListener("scroll", onScroll);
     let previousEntries = [];
+    const newObservables = [];
+    let callbackCallTimeout;
 
     return {
       disconnect() {
         toObserve.length = 0;
+        previousEntries.length = 0;
       },
       observe(element) {
         toObserve.push(element);
         observed.push(element);
-        const newEntries = [element].map((el) => intersectionObserverEntry(el, rootMargin));
-        viewPortUpdate(newEntries);
-        previousEntries = previousEntries.concat(newEntries);
+        newObservables.push(element);
+        clearTimeout(callbackCallTimeout);
+        callbackCallTimeout = setTimeout(onObserve, 0);
       },
       unobserve(element) {
         const idx = toObserve.indexOf(element);
@@ -42,10 +45,16 @@ module.exports = function FakeIntersectionObserver(browser) {
       }
     };
 
+    function onObserve() {
+      const newEntries = newObservables.map((el) => intersectionObserverEntry(el, rootMargin));
+      newObservables.length = 0;
+      viewPortUpdate(newEntries);
+      previousEntries = previousEntries.concat(newEntries);
+    }
+
     function onScroll() {
       const entries = toObserve.map((el) => intersectionObserverEntry(el, rootMargin));
       const changedEntries = entries.filter(hasChanged);
-
       if (changedEntries.length > 0) {
         viewPortUpdate(changedEntries);
       }

--- a/test/intersection-observer-test.js
+++ b/test/intersection-observer-test.js
@@ -43,10 +43,11 @@ describe("IntersectionObserver", () => {
     expect(browser.document.getElementsByTagName("img")[1].src).to.be.ok;
   });
 
-  it("calls viewPortUpdate with correct element when observing new elements", async () => {
+  it("calls viewPortUpdate with correct elements when observing new elements", async () => {
     const browser = await Browser(app).navigateTo("/");
     const [element1] = browser.document.getElementsByClassName("observer-test-1");
     const [element2] = browser.document.getElementsByClassName("observer-test-2");
+    const [element3] = browser.document.getElementsByClassName("observer-test-3");
 
     browser.window.IntersectionObserver = IntersectionObserver(browser);
     let intersectingEntries = [];
@@ -56,14 +57,21 @@ describe("IntersectionObserver", () => {
     });
 
     observer.observe(element1);
-
-    expect(intersectingEntries).to.have.length(1);
-    expect(intersectingEntries[0]).to.have.property("target", element1);
-
     observer.observe(element2);
 
+    expect(intersectingEntries).to.have.length(0);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(intersectingEntries).to.have.length(2);
+    expect(intersectingEntries[0]).to.have.property("target", element1);
+    expect(intersectingEntries[1]).to.have.property("target", element2);
+
+    observer.observe(element3);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
     expect(intersectingEntries).to.have.length(1);
-    expect(intersectingEntries[0]).to.have.property("target", element2);
+    expect(intersectingEntries[0]).to.have.property("target", element3);
   });
 
   it("calls viewPortUpdate with correct element when scrolling", async () => {
@@ -88,6 +96,8 @@ describe("IntersectionObserver", () => {
 
     observer.observe(element1);
     observer.observe(element2);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
     timesCalled = 0;
     intersectingEntries.length = 0;
 
@@ -120,5 +130,50 @@ describe("IntersectionObserver", () => {
     expect(intersectingEntries).to.have.length(2);
     expect(intersectingEntries[0]).to.have.property("target", element1);
     expect(intersectingEntries[1]).to.have.property("target", element2);
+  });
+
+  it("clears targets on disconnect", async () => {
+    const browser = await Browser(app).navigateTo("/");
+    browser.window._resize(1024, 100);
+    const [element1] = browser.document.getElementsByClassName("observer-test-1");
+    const [element2] = browser.document.getElementsByClassName("observer-test-2");
+
+    element1._setBoundingClientRect({ top: 200, bottom: 300 });
+    element2._setBoundingClientRect({ top: 400, bottom: 500 });
+
+    browser.setElementsToScroll(() => [element1, element2]);
+
+    browser.window.IntersectionObserver = IntersectionObserver(browser);
+    let timesCalled = 0;
+    const observer = browser.window.IntersectionObserver(() => timesCalled++);
+
+    observer.observe(element1);
+    observer.observe(element2);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    timesCalled = 0;
+
+    browser.scrollToTopOfElement(element1, -1);
+    browser.scrollToTopOfElement(element2, -1);
+    browser.window.scroll(0, 0);
+    expect(timesCalled).to.equal(3);
+
+    timesCalled = 0;
+    observer.disconnect();
+
+    browser.scrollToTopOfElement(element1, -1);
+    browser.scrollToTopOfElement(element2, -1);
+    browser.window.scroll(0, 0);
+    expect(timesCalled).to.equal(0);
+
+    observer.observe(element1);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    timesCalled = 0;
+
+    browser.scrollToTopOfElement(element1, -1);
+    browser.scrollToTopOfElement(element2, -1);
+    browser.window.scroll(0, 0);
+    expect(timesCalled).to.equal(2);
   });
 });


### PR DESCRIPTION
Make `IntersectionObserver` behaviour closer to a real browser. 

```js
const observer = new IntersectionObserver((entries) => console.log("check", entries));
observer.observe(el1);
observer.observe(el2);
console.log("done");
```

Before

```js
// check [el1]
// check [el2]
// done
```

After

```js
// done
...
// check [el1, el2]
```

Inconsistency caused a race condition in Solveig to remain uncaught in test suite.