### PR TITLE
Lock cheerio version temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "git://github.com/ExpressenAB/tallahassee.git"
   },
   "dependencies": {
-    "cheerio": "^1.0.0-rc.3",
+    "cheerio": "1.0.0-rc.3",
     "domexception": "^2.0.0",
     "node-fetch": "^2.6.0",
     "supertest": "^4.0.2"


### PR DESCRIPTION
Cheerio introduces breaking changes in 1.0.0-rc.4 https://github.com/cheeriojs/cheerio/releases/tag/v1.0.0-rc.4
Lock version until we can make a proper bump.