### PR TITLE
Only run javascript script elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 ---------
 
+# Unreleased
+- Only consider the following types as javascript `undefined`, `"text/javascript"` and legacy `"application/javascript"`
+
 # 10.5.3
 - Lock cheerio version to 1.0.0-rc.3 until breaking changes can be maintained
 

--- a/app/assets/public/index.html
+++ b/app/assets/public/index.html
@@ -2,21 +2,21 @@
 <html lang="sv" class="no-js">
   <head>
     <title>Zombie killer</title>
-    <script>
+    <script id="implicit-javascript-script">
     (function IIFE() {
       document.documentElement.classList.remove("no-js");
     })();
     </script>
-    <script type="module">
+    <script type="module" id="module-script">
       window.moduleScriptExecuted = true;
     </script>
-    <script type="application/ld+json">
+    <script type="application/ld+json" id="data-block-script">
       {"a": 1}
     </script>
-    <script type="custom/javascript">
+    <script type="custom/javascript" id="custom-script">
       window.customScriptIgnoredFailed = true;
     </script>
-    <script type="application/javascript">
+    <script type="application/javascript" id="legacy-script">
       window.legacyScriptExecuted = true;
     </script>
   </head>
@@ -88,7 +88,7 @@
       <button name="named-button-with-value" value="1" formaction="https://www.example.com/2">Send name and value</button>
     </form>
     <img class="lazy-load" data-img-source="/images/tallahassee-1.png">
-    <script type="text/javascript">
+    <script type="text/javascript" id="explicit-javascript-script">
       (function IIFE() {
         window.scriptsAreExecutedInBody = true;
       })();

--- a/app/assets/public/index.html
+++ b/app/assets/public/index.html
@@ -7,8 +7,17 @@
       document.documentElement.classList.remove("no-js");
     })();
     </script>
+    <script type="module">
+      window.moduleScriptExecuted = true;
+    </script>
     <script type="application/ld+json">
       {"a": 1}
+    </script>
+    <script type="custom/javascript">
+      window.customScriptIgnoredFailed = true;
+    </script>
+    <script type="application/javascript">
+      window.legacyScriptExecuted = true;
     </script>
   </head>
   <body>
@@ -79,7 +88,7 @@
       <button name="named-button-with-value" value="1" formaction="https://www.example.com/2">Send name and value</button>
     </form>
     <img class="lazy-load" data-img-source="/images/tallahassee-1.png">
-    <script>
+    <script type="text/javascript">
       (function IIFE() {
         window.scriptsAreExecutedInBody = true;
       })();

--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ function Tallahassee(app, options = {}) {
         const $script = script.$elm;
 
         const scriptType = $script.attr("type");
-        if (scriptType && !/javascript/i.test(scriptType)) return;
+        if (scriptType && !/(text|application)\/(javascript)/i.test(scriptType)) return;
 
         const scriptBody = $script.html();
         if (scriptBody) vm.runInNewContext(scriptBody, window);

--- a/test/index.js
+++ b/test/index.js
@@ -194,13 +194,38 @@ describe("Tallahassee", () => {
       expect(browser.window).to.not.have.property("scriptsAreExecutedInBody");
     });
 
-    it("does not run if script type is not JavaScript", () => {
+    it("does not run if script type is 'module'", () => {
       const scriptElement = browser.document.getElementsByTagName("script")[1];
-      const scriptType = scriptElement.$elm.attr("type");
+      expect(scriptElement.type).to.equal("module");
 
-      expect(scriptType).to.be.ok;
-      expect(scriptType).to.not.include("javascript");
       browser.runScript(scriptElement);
+
+      expect(browser.window.moduleScriptExecuted).to.be.undefined;
+    });
+
+    it("does not run if script is not JavaScript", () => {
+      const dataBlockScript = browser.document.getElementsByTagName("script")[2];
+      expect(dataBlockScript.type).to.equal("application/ld+json");
+
+      const customScript = browser.document.getElementsByTagName("script")[3];
+      expect(customScript.type).to.equal("custom/javascript");
+
+      browser.runScript(dataBlockScript);
+      browser.runScript(customScript);
+
+      expect(browser.window.customScriptIgnoredFailed).to.be.undefined;
+      expect(browser.window).to.not.have.property("scriptsAreExecutedInBody");
+    });
+
+    it("runs supplied legacy script", () => {
+      expect(browser.window.legacyScriptExecuted).to.be.undefined;
+
+      const legacyScript = browser.document.getElementsByTagName("script")[4];
+      expect(legacyScript.type).to.equal("application/javascript");
+
+      browser.runScript(legacyScript);
+
+      expect(browser.window.legacyScriptExecuted).to.be.true;
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -186,7 +186,9 @@ describe("Tallahassee", () => {
       expect(browser.document.documentElement.classList.contains("no-js")).to.be.true;
       expect(browser.window).to.not.have.property("scriptsAreExecutedInBody");
 
-      const scriptElement = browser.document.getElementsByTagName("script")[0];
+      const scriptElement = browser.document.getElementById("implicit-javascript-script");
+      expect(scriptElement).to.exist;
+
 
       browser.runScript(scriptElement);
 
@@ -195,7 +197,8 @@ describe("Tallahassee", () => {
     });
 
     it("does not run if script type is 'module'", () => {
-      const scriptElement = browser.document.getElementsByTagName("script")[1];
+      const scriptElement = browser.document.getElementById("module-script");
+      expect(scriptElement).to.exist;
       expect(scriptElement.type).to.equal("module");
 
       browser.runScript(scriptElement);
@@ -204,10 +207,12 @@ describe("Tallahassee", () => {
     });
 
     it("does not run if script is not JavaScript", () => {
-      const dataBlockScript = browser.document.getElementsByTagName("script")[2];
+      const dataBlockScript = browser.document.getElementById("data-block-script");
+      expect(dataBlockScript).to.exist;
       expect(dataBlockScript.type).to.equal("application/ld+json");
 
-      const customScript = browser.document.getElementsByTagName("script")[3];
+      const customScript = browser.document.getElementById("custom-script");
+      expect(customScript).to.exist;
       expect(customScript.type).to.equal("custom/javascript");
 
       browser.runScript(dataBlockScript);
@@ -220,7 +225,8 @@ describe("Tallahassee", () => {
     it("runs supplied legacy script", () => {
       expect(browser.window.legacyScriptExecuted).to.be.undefined;
 
-      const legacyScript = browser.document.getElementsByTagName("script")[4];
+      const legacyScript = browser.document.getElementById("legacy-script");
+      expect(legacyScript).to.exist;
       expect(legacyScript.type).to.equal("application/javascript");
 
       browser.runScript(legacyScript);


### PR DESCRIPTION
A custom script type can be used to disable resource loading and execution. Tallahassee needs to disregard these tags when running scripts.

Only desired type to run is `"text/javascript"` per the HTML specification. Tallahassee has in the past only checked for presence of "javascript" in the type which permits the old standard `"application/javascript"` as well as matching [non standard types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#javascript_types). Kept it semi-loose to not break old standard compliant types, but ignored non standard ones. 